### PR TITLE
move dome close earlier

### DIFF
--- a/scripts/pilot
+++ b/scripts/pilot
@@ -333,12 +333,12 @@ class Pilot:
                 self.log.warn('closing and parking')
                 # TODO: discuss what should happen when dome closes in middle of
                 # observing?
-                await self.cancelRunningScript()
-                self.park_scope()
                 execute_command('exq pause')
                 execute_command('cam abort')
                 if self.domeOpen:
                     self.close_dome()
+                await self.cancelRunningScript()
+                self.park_scope()
             elif reason == 'hw':
                 # just pause the queue until fixed
                 execute_command('exq pause')


### PR DESCRIPTION
fixes #52 by moving dome closure up the list of actions in case of bad weather. 

I've left cancelling the running script as the first action so we reduce the number of crap frames the archiving/data reduction have to deal with. This action should be near instantaneous so I don't see an issue here.