### PR TITLE
Two updates to the scheduler for Astroplan compatability

### DIFF
--- a/gtecs/tecs_modules/scheduler.py
+++ b/gtecs/tecs_modules/scheduler.py
@@ -373,7 +373,7 @@ class Queue:
                                  'Moon',
                                  'MoonSep']
 
-        self.time_constraint = [TimeConstraint(self.start_arr, self.stop_arr)]
+        self.time_constraint = [TimeConstraint(Time(self.start_arr), Time(self.stop_arr))]
         self.time_constraint_name = ['Time']
 
         self.mintime_constraints = [AtNightConstraint(self.maxsunalt_arr),


### PR DESCRIPTION
When entering  #57 there were only two changes needed to bring the current, admittedly flawed, scheduler up-to-date with the latest version of Astroplan and Astropy.

Note the speed of the scheduler has taken a massive hit, but at least it doesn’t raise an exception.