### PR TITLE
Add pool_pre_ping to SQL engine

### DIFF
--- a/gtecs/database/engine.py
+++ b/gtecs/database/engine.py
@@ -8,7 +8,8 @@ from gtecs.tecs_modules import params
 # TODO: build name from params
 
 engine_string = 'mysql+pymysql://' + str(params.DATABASE_LOCATION)
-engine = create_engine(engine_string, echo=params.DATABASE_ECHO)
+engine = create_engine(engine_string, echo=params.DATABASE_ECHO,
+                       pool_pre_ping=True) # needs sqlalchemy >= 1.2
 
 
 @contextmanager


### PR DESCRIPTION
A small change to hopefully fix #138 and #193.

Note this requires SQLAlchemy greater than v1.2, which is currently in pre-release. Easy enough to install with pip.