### PR TITLE
Emergency shutdown triggers alert

### DIFF
--- a/gtecs/flags.py
+++ b/gtecs/flags.py
@@ -217,7 +217,8 @@ class Status:
         """Create the emergency shutdown file"""
         self._load()
         if not self.emergency_shutdown:
-            send_slack_msg('GOTO has triggered emergency shutdown: {}'.format(why))
+            send_slack_msg('{} has triggered emergency shutdown: {}'.format(
+                           params.TELESCOP, why))
         cmd = 'touch ' + self.emergency_file
         os.system(cmd)
         with open(self.emergency_file, 'w') as f:

--- a/scripts/pilot
+++ b/scripts/pilot
@@ -789,7 +789,8 @@ class Pilot:
         Send a warning and then shut down
         """
         self.log.warn('performing emergency shutdown: {}'.format(why))
-        send_slack_msg('GOTO-LAPALMA is performing an emergency shutdown: {}'.format(why))
+        send_slack_msg('{} pilot is performing an emergency shutdown: {}'.format(
+                       params.TELESCOP, why))
 
         self.log.warn('closing dome immediately')
         if self.domeOpen:


### PR DESCRIPTION
If an `EMERGENCY-SHUTDOWN` file is created by the system when one doesn't already exist, it will now send a message to Slack.

First mentioned in #154 , and one of the points in #156.