### PR TITLE
Add dome stutter steps to south side when opening

### DIFF
--- a/gtecs/controls/dome_control.py
+++ b/gtecs/controls/dome_control.py
@@ -200,7 +200,7 @@ class AstroHavenDome:
 
         self.move_code = {'south':{'open':b'a','close':b'A'},
                           'north':{'open':b'b','close':b'B'}}
-        self.move_time = {'south':{'open':25.,'close':26.},
+        self.move_time = {'south':{'open':36.,'close':26.},
                           'north':{'open':24.,'close':24.}}
 
         self.fake = False


### PR DESCRIPTION
See title. By increasing the gap between commands for the first half of opening the south side there's much less of a jolt when the top shutter comes over.