### PR TITLE
Use Astropy to cooking/uncook SiTech coordinates

### DIFF
--- a/gtecs/hardware/sitech.py
+++ b/gtecs/hardware/sitech.py
@@ -332,8 +332,8 @@ class SiTech(object):
         self.target_radec = (ra, dec)
 
         # first need to "cook" the coordinates into SiTech's JNow
-        ra_jnow, dec_jnow = cook(ra * 180 / 24, dec, Time.now().jd)
-        ra_jnow *= 24 / 180
+        ra_jnow, dec_jnow = cook(ra * 360 / 24, dec, Time.now().jd)
+        ra_jnow *= 24 / 360
         self.log.debug('Cooked {:.6f}/{:.6f} to {:.6f}/{:.6f}'.format(ra, dec, ra_jnow, dec_jnow))
 
         command = self.commands['SLEW_RADEC'].format(float(ra_jnow), float(dec_jnow))


### PR DESCRIPTION
As detailed in #329, we now have our own functions to convert to and from the "JNow" coordinates used by SiTech.

Closes #329.