### PR TITLE
Fix autoclose logic

### DIFF
--- a/gtecs/daemons/dome_daemon.py
+++ b/gtecs/daemons/dome_daemon.py
@@ -474,6 +474,7 @@ class DomeDaemon(BaseDaemon):
             reasons = self.info['conditions_bad_reasons']
             if self.info['mode'] == 'manual' and not self.info['autoclose']:
                 self.log.warning('Conditions bad ({}), but autoclose is disabled!'.format(reasons))
+                self.lockdown = False
             else:
                 self.log.warning('Lockdown: conditions bad ({})!'.format(reasons))
                 self.lockdown = True
@@ -482,7 +483,7 @@ class DomeDaemon(BaseDaemon):
             self.lockdown = False
 
         # React to a lockdown order
-        if self.lockdown and self.info['dome'] != 'closed':
+        if self.lockdown and self.info['dome'] != 'closed' and self.info['autoclose']:
             self.log.warning('Autoclosing dome due to lockdown')
             if not self.close_flag:
                 reasons = ''


### PR DESCRIPTION
An error in the autoclose logic meant turning off autoclose when in lockdown didn't actually clear the state, so when trying to open the dome still closed. This both fixes the former issue and prevents the second from happening.