### PR TITLE
Account for RAs > 24 in all cases

### DIFF
--- a/gtecs/hardware/sitech.py
+++ b/gtecs/hardware/sitech.py
@@ -180,6 +180,8 @@ class SiTech(object):
         # need to "uncook" the SiTech coordinates into J2000
         ra_j2000, dec_j2000 = uncook(ra_temp * 360 / 24, dec_temp, self._jd)
         self._ra = ra_j2000 * 24 / 360
+        if self._ra >= 24:
+            self._ra -= 24
         self._dec = dec_j2000
         self.log.debug('Uncooked {:.6f}/{:.6f} to {:.6f}/{:.6f}'.format(ra_temp, dec_temp,
                                                                         self._ra, self._dec))
@@ -334,6 +336,8 @@ class SiTech(object):
         # first need to "cook" the coordinates into SiTech's JNow
         ra_jnow, dec_jnow = cook(ra * 360 / 24, dec, Time.now().jd)
         ra_jnow *= 24 / 360
+        if ra_jnow >= 24:
+            ra_jnow -= 24
         self.log.debug('Cooked {:.6f}/{:.6f} to {:.6f}/{:.6f}'.format(ra, dec, ra_jnow, dec_jnow))
 
         command = self.commands['SLEW_RADEC'].format(float(ra_jnow), float(dec_jnow))
@@ -356,6 +360,8 @@ class SiTech(object):
         # first need to "cook" the coordinates into SiTech's JNow
         ra_jnow, dec_jnow = cook(ra * 180 / 24, dec, Time.now().jd)
         ra_jnow *= 24 / 180
+        if ra_jnow >= 24:
+            ra_jnow -= 24
         self.log.debug('Cooked {:.6f}/{:.6f} to {:.6f}/{:.6f}'.format(ra, dec, ra_jnow, dec_jnow))
 
         command = self.commands['SYNC_RADEC'].format(float(ra_jnow), float(dec_jnow))


### PR DESCRIPTION
Fixes #357.

A better fix would be to use Astropy coordinates throughout the mount system, but this should do for now.