### PR TITLE
asynchronous checking of schedule

### DIFF
--- a/gtecs/daemons.py
+++ b/gtecs/daemons.py
@@ -274,11 +274,15 @@ def check_daemon(daemon_id):
     raise errors.DaemonStatusError(errstr)
 
 
-def daemon_function(daemon_id, function_name, args=None, timeout=0.):
+def daemon_function(daemon_id, function_name, args=None, timeout=0., asynchronous=False):
     """Run a given function on a daemon."""
     check_daemon(daemon_id)  # Will raise an error if one occurs
 
     with daemon_proxy(daemon_id, timeout) as daemon:
+        if asynchronous:
+            # enable asynchronous running of daemon.
+            # result will be a Pyro.Future - check result.ready to see if it's complete
+            daemon._pyroAsync()
         try:
             function = getattr(daemon, function_name)
         except AttributeError:

--- a/gtecs/pilot.py
+++ b/gtecs/pilot.py
@@ -22,7 +22,7 @@ from .asyncio_protocols import SimpleProtocol
 from .errors import RecoveryError
 from .flags import Conditions, Status
 from .misc import execute_command, send_email
-from .observing import (cameras_are_cool, check_schedule, filters_are_homed,
+from .observing import (cameras_are_cool, check_schedule_async, filters_are_homed,
                         get_pointing_status)
 from .slack import send_slack_msg
 
@@ -144,7 +144,7 @@ class Pilot(object):
                     # check scheduler daemon
                     self.log.debug('checking scheduler')
 
-                    check_results = check_schedule()
+                    check_results = await check_schedule_async()
                     self.new_id, self.new_priority, self.new_mintime = check_results
                     # NOTE we don't actually use the priority anywhere in the pilot!
 


### PR DESCRIPTION
Hi @martinjohndyer 

I don't know how long schedule checks actually take these days, and I don't have much of a working system to test this, but I thought it would be useful to implement nevertheless.

Resolves #370 and is handy to have implemented in case we ever want to run other Pyro calls in the background without blocking operations.

This will need careful testing with a full database and an operating fake pilot, but the basic code works...