### PR TITLE
Put debug line in try/except

### DIFF
--- a/gtecs/daemons/cam_daemon.py
+++ b/gtecs/daemons/cam_daemon.py
@@ -313,18 +313,21 @@ class CamDaemon(BaseDaemon):
         temp_info['num_taken'] = self.num_taken
         temp_info['glance'] = self.run_number < 0
 
-        # Print a debug log line
-        now_strs = ['{}:{}'.format(tel, temp_info[tel]['status'])
-                    for tel in sorted(params.TEL_DICT)]
-        now_str = ' '.join(now_strs)
-        if not self.info:
-            self.log.debug('Cameras are {}'.format(now_str))
-        else:
-            old_strs = ['{}:{}'.format(tel, self.info[tel]['status'])
+        # Write debug log line
+        try:
+            now_strs = ['{}:{}'.format(tel, temp_info[tel]['status'])
                         for tel in sorted(params.TEL_DICT)]
-            old_str = ' '.join(old_strs)
-            if now_str != old_str:
+            now_str = ' '.join(now_strs)
+            if not self.info:
                 self.log.debug('Cameras are {}'.format(now_str))
+            else:
+                old_strs = ['{}:{}'.format(tel, self.info[tel]['status'])
+                            for tel in sorted(params.TEL_DICT)]
+                old_str = ' '.join(old_strs)
+                if now_str != old_str:
+                    self.log.debug('Cameras are {}'.format(now_str))
+        except Exception:
+            self.log.error('Could not write current status')
 
         # Update the master info dict
         self.info = temp_info

--- a/gtecs/daemons/conditions_daemon.py
+++ b/gtecs/daemons/conditions_daemon.py
@@ -176,7 +176,7 @@ class ConditionsDaemon(BaseDaemon):
         # Get internal info
         temp_info['flags'] = self.flags
 
-        # Print a debug log line
+        # Write debug log line
         # NONE, we do it already
 
         # Update the master info dict

--- a/gtecs/daemons/dome_daemon.py
+++ b/gtecs/daemons/dome_daemon.py
@@ -453,11 +453,14 @@ class DomeDaemon(BaseDaemon):
         # Get other internal info
         temp_info['lockdown'] = self.lockdown
 
-        # Print a debug log line
-        if not self.info:
-            self.log.debug('Dome is {}'.format(temp_info['dome']))
-        elif temp_info['dome'] != self.info['dome']:
-            self.log.debug('Dome is {}'.format(temp_info['dome']))
+        # Write debug log line
+        try:
+            if not self.info:
+                self.log.debug('Dome is {}'.format(temp_info['dome']))
+            elif temp_info['dome'] != self.info['dome']:
+                self.log.debug('Dome is {}'.format(temp_info['dome']))
+        except Exception:
+            self.log.error('Could not write current status')
 
         # Update the master info dict
         self.info = temp_info

--- a/gtecs/daemons/exq_daemon.py
+++ b/gtecs/daemons/exq_daemon.py
@@ -134,14 +134,19 @@ class ExqDaemon(BaseDaemon):
         else:
             temp_info['exposing'] = False
 
-        # Print a debug log line
-        now_str = '{} ({:.0f} in queue)'.format(temp_info['status'], temp_info['queue_length'])
-        if not self.info:
-            self.log.debug('Exposure queue is {}'.format(now_str))
-        else:
-            old_str = '{} ({:.0f} in queue)'.format(self.info['status'], self.info['queue_length'])
-            if now_str != old_str:
+        # Write debug log line
+        try:
+            now_str = '{} ({:.0f} in queue)'.format(temp_info['status'],
+                                                    temp_info['queue_length'])
+            if not self.info:
                 self.log.debug('Exposure queue is {}'.format(now_str))
+            else:
+                old_str = '{} ({:.0f} in queue)'.format(self.info['status'],
+                                                        self.info['queue_length'])
+                if now_str != old_str:
+                    self.log.debug('Exposure queue is {}'.format(now_str))
+        except Exception:
+            self.log.error('Could not write current status')
 
         # Update the master info dict
         self.info = temp_info

--- a/gtecs/daemons/filt_daemon.py
+++ b/gtecs/daemons/filt_daemon.py
@@ -151,18 +151,21 @@ class FiltDaemon(BaseDaemon):
                 self.log.debug('', exc_info=True)
                 temp_info[tel] = None
 
-        # Print a debug log line
-        now_strs = ['{}:{}'.format(tel, temp_info[tel]['status'])
-                    for tel in sorted(params.TEL_DICT)]
-        now_str = ' '.join(now_strs)
-        if not self.info:
-            self.log.debug('Filter wheels are {}'.format(now_str))
-        else:
-            old_strs = ['{}:{}'.format(tel, self.info[tel]['status'])
+        # Write debug log line
+        try:
+            now_strs = ['{}:{}'.format(tel, temp_info[tel]['status'])
                         for tel in sorted(params.TEL_DICT)]
-            old_str = ' '.join(old_strs)
-            if now_str != old_str:
+            now_str = ' '.join(now_strs)
+            if not self.info:
                 self.log.debug('Filter wheels are {}'.format(now_str))
+            else:
+                old_strs = ['{}:{}'.format(tel, self.info[tel]['status'])
+                            for tel in sorted(params.TEL_DICT)]
+                old_str = ' '.join(old_strs)
+                if now_str != old_str:
+                    self.log.debug('Filter wheels are {}'.format(now_str))
+        except Exception:
+            self.log.error('Could not write current status')
 
         # Update the master info dict
         self.info = temp_info

--- a/gtecs/daemons/fli_interface.py
+++ b/gtecs/daemons/fli_interface.py
@@ -200,7 +200,7 @@ class FLIDaemon(BaseDaemon):
         temp_info['foc_serials'] = list(self.foc_serials)
         temp_info['filt_serials'] = list(self.filt_serials)
 
-        # Print a debug log line
+        # Write debug log line
         # NONE, nothing really changes
 
         # Update the master info dict

--- a/gtecs/daemons/foc_daemon.py
+++ b/gtecs/daemons/foc_daemon.py
@@ -158,18 +158,21 @@ class FocDaemon(BaseDaemon):
                 self.log.debug('', exc_info=True)
                 temp_info[tel] = None
 
-        # Print a debug log line
-        now_strs = ['{}:{}'.format(tel, temp_info[tel]['status'])
-                    for tel in sorted(params.TEL_DICT)]
-        now_str = ' '.join(now_strs)
-        if not self.info:
-            self.log.debug('Focusers are {}'.format(now_str))
-        else:
-            old_strs = ['{}:{}'.format(tel, self.info[tel]['status'])
+        # Write debug log line
+        try:
+            now_strs = ['{}:{}'.format(tel, temp_info[tel]['status'])
                         for tel in sorted(params.TEL_DICT)]
-            old_str = ' '.join(old_strs)
-            if now_str != old_str:
+            now_str = ' '.join(now_strs)
+            if not self.info:
                 self.log.debug('Focusers are {}'.format(now_str))
+            else:
+                old_strs = ['{}:{}'.format(tel, self.info[tel]['status'])
+                            for tel in sorted(params.TEL_DICT)]
+                old_str = ' '.join(old_strs)
+                if now_str != old_str:
+                    self.log.debug('Focusers are {}'.format(now_str))
+        except Exception:
+            self.log.error('Could not write current status')
 
         # Update the master info dict
         self.info = temp_info

--- a/gtecs/daemons/mnt_daemon.py
+++ b/gtecs/daemons/mnt_daemon.py
@@ -279,11 +279,14 @@ class MntDaemon(BaseDaemon):
         temp_info['target_dist'] = self._get_target_distance()
         temp_info['step'] = self.step
 
-        # Print a debug log line
-        if not self.info:
-            self.log.debug('Mount is {}'.format(temp_info['status']))
-        elif temp_info['status'] != self.info['status']:
-            self.log.debug('Mount is {}'.format(temp_info['status']))
+        # Write debug log line
+        try:
+            if not self.info:
+                self.log.debug('Mount is {}'.format(temp_info['status']))
+            elif temp_info['status'] != self.info['status']:
+                self.log.debug('Mount is {}'.format(temp_info['status']))
+        except Exception:
+            self.log.error('Could not write current status')
 
         # Update the master info dict
         self.info = temp_info

--- a/gtecs/daemons/power_daemon.py
+++ b/gtecs/daemons/power_daemon.py
@@ -226,7 +226,7 @@ class PowerDaemon(BaseDaemon):
                 if unit_name not in self.bad_hardware:
                     self.bad_hardware.add(unit_name)
 
-        # Print a debug log line
+        # Write debug log line
         # NONE, no quick status
 
         # Update the master info dict

--- a/gtecs/daemons/scheduler_daemon.py
+++ b/gtecs/daemons/scheduler_daemon.py
@@ -69,20 +69,24 @@ class SchedulerDaemon(BaseDaemon):
             self.log.debug('', exc_info=True)
             temp_info['next_pointing'] = None
 
-        # Print a debug log line
-        now_pointing = temp_info['next_pointing']
-        if not self.info:
-            if now_pointing is not None:
-                self.log.debug('Scheduler returns pointing {}'.format(now_pointing.pointing_id))
-            else:
-                self.log.debug('Scheduler returns None')
-        else:
-            old_pointing = self.info['next_pointing']
-            if now_pointing != old_pointing:
+        # Write debug log line
+        try:
+            now_pointing = temp_info['next_pointing']
+            if not self.info:
                 if now_pointing is not None:
                     self.log.debug('Scheduler returns pointing {}'.format(now_pointing.pointing_id))
                 else:
                     self.log.debug('Scheduler returns None')
+            else:
+                old_pointing = self.info['next_pointing']
+                if now_pointing != old_pointing:
+                    if now_pointing is not None:
+                        self.log.debug('Scheduler returns pointing {}'.format(
+                            now_pointing.pointing_id))
+                    else:
+                        self.log.debug('Scheduler returns None')
+        except Exception:
+            self.log.error('Could not write current status')
 
         # Update the master info dict
         self.info = temp_info

--- a/gtecs/daemons/sentinel_daemon.py
+++ b/gtecs/daemons/sentinel_daemon.py
@@ -171,18 +171,22 @@ class SentinelDaemon(BaseDaemon):
         temp_info['processed_events'] = self.processed_events
         temp_info['interesting_events'] = self.interesting_events
 
-        # Print a debug log line
-        now_str = '{} ({} processed, {} interesting)'.format(temp_info['status'],
-                                                             temp_info['processed_events'],
-                                                             temp_info['interesting_events'])
-        if not self.info:
-            self.log.debug('Sentinel is {}'.format(now_str))
-        else:
-            old_str = '{} ({} processed, {} interesting)'.format(self.info['status'],
-                                                                 self.info['processed_events'],
-                                                                 self.info['interesting_events'])
-            if now_str != old_str:
+        # Write debug log line
+        try:
+            now_str = '{} ({} processed, {} interesting)'.format(temp_info['status'],
+                                                                 temp_info['processed_events'],
+                                                                 temp_info['interesting_events'])
+            if not self.info:
                 self.log.debug('Sentinel is {}'.format(now_str))
+            else:
+                old_str = '{} ({} processed, {} interesting)'.format(
+                    self.info['status'],
+                    self.info['processed_events'],
+                    self.info['interesting_events'])
+                if now_str != old_str:
+                    self.log.debug('Sentinel is {}'.format(now_str))
+        except Exception:
+            self.log.error('Could not write current status')
 
         # Update the master info dict
         self.info = temp_info


### PR DESCRIPTION
Occasionally we've seen the cam/foc/filt daemons fail during shutdown, requiring them to be restarted in the evening. See log:
```
2018/12/16 08:02:11.277:filt:ERROR - Failed to get filter wheel 1 info
2018/12/16 17:10:42.812:filt:INFO - Daemon shutting down
2018/12/16 17:10:43.015:filt:INFO - Daemon successfully shut down
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib64/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib64/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/home/goto/.local/lib/python3.6/site-packages/gtecs/daemons/filt_daemon.py", line 60, in _control_thread
    self._get_info()
  File "/home/goto/.local/lib/python3.6/site-packages/gtecs/daemons/filt_daemon.py", line 156, in _get_info
    for tel in sorted(params.TEL_DICT)]
  File "/home/goto/.local/lib/python3.6/site-packages/gtecs/daemons/filt_daemon.py", line 156, in <listcomp>
    for tel in sorted(params.TEL_DICT)]
TypeError: 'NoneType' object is not subscriptable
```

I think it's clear the debug line is the cause when the FLI interfaces are shut down. This puts it in a try/except so it shouldn't hang the whole daemon from now on.