### PR TITLE
Increase buffer between last observation and end of observation

### DIFF
--- a/gtecs/pilot.py
+++ b/gtecs/pilot.py
@@ -364,7 +364,7 @@ class Pilot(object):
             await self.observe(until_sunalt=90)
         else:
             # await self.observe(until_sunalt=-14.6, last_obs_sunalt=-15)
-            await self.observe(until_sunalt=-12, last_obs_sunalt=-12.4)
+            await self.observe(until_sunalt=-12, last_obs_sunalt=-14)
 
         # Morning jobs
         await self.run_through_jobs(self.morning_jobs, rising=True,


### PR DESCRIPTION
The last set of science exposures is often cut off. This increases the time between the pilot scheduling the last set of observations (now at -14 sun alt) and it cutting off due to the ultimate sun alt limit of -12.

This should give a ~6 minute window or so, plenty enough to complete the set.