### PR TITLE
Add a check for any None infos in FLI-related hardware monitors

### DIFF
--- a/gtecs/monitors.py
+++ b/gtecs/monitors.py
@@ -935,7 +935,7 @@ class CamMonitor(BaseMonitor):
     def get_hardware_status(self):
         """Get the current status of the hardware."""
         info = self.get_info()
-        if info is None:
+        if info is None or any([info[tel] is None for tel in params.TEL_DICT]):
             self.hardware_status = STATUS_UNKNOWN
             return STATUS_UNKNOWN
 
@@ -1036,7 +1036,7 @@ class FiltMonitor(BaseMonitor):
     def get_hardware_status(self):
         """Get the current status of the hardware."""
         info = self.get_info()
-        if info is None:
+        if info is None or any([info[tel] is None for tel in params.TEL_DICT]):
             self.hardware_status = STATUS_UNKNOWN
             return STATUS_UNKNOWN
 
@@ -1137,7 +1137,7 @@ class FocMonitor(BaseMonitor):
     def get_hardware_status(self):
         """Get the current status of the hardware."""
         info = self.get_info()
-        if info is None:
+        if info is None or any([info[tel] is None for tel in params.TEL_DICT]):
             self.hardware_status = STATUS_UNKNOWN
             return STATUS_UNKNOWN
 


### PR DESCRIPTION
The pilot failing as detailed here #380 were due to the same error in the daemon monitors: specifically the filter wheel monitor failing to report if it was homed or not. This was because the daemon reported no info dict for the given filter wheel, as it had been powered off.

This PR adds checks for if any of the info for individual FLI units (cams/focs/filts) are missing and reports that as an error on the same level of the entire info dict missing.