### PR TITLE
Sentinel event logging

### DIFF
--- a/gtecs/daemons/sentinel_daemon.py
+++ b/gtecs/daemons/sentinel_daemon.py
@@ -250,6 +250,11 @@ class SentinelDaemon(BaseDaemon):
 
         msg = '\n'.join(title + details + table)
 
+        # Extra for events with no tiles that passed mask
+        if len(event.tile_table) == 0:
+            high_prob = event.full_table[0]['prob']
+            msg += '\nNo tiles passed filter (highest prob is {:.2f}%)'.format(high_prob * 100)
+
         send_slack_msg(msg)
 
     # Control functions


### PR DESCRIPTION
Thanks to GOTO-OBS/goto-alert#20 I've reworked some of the logging in GOTO-alert (GOTO-OBS/goto-alert#21). This PR follows on from that.

Also, it notably adds a Slack alert should the event handler crash (closes #410). Hopefully this shouldn't happen too often, it will do it for every event not just the interesting ones but the non-interesting ones should return pretty quickly. 