### PR TITLE
Add total covered probability to sentinel Slack alerts

### DIFF
--- a/gtecs/daemons/sentinel_daemon.py
+++ b/gtecs/daemons/sentinel_daemon.py
@@ -221,8 +221,13 @@ class SentinelDaemon(BaseDaemon):
             # If the event was returned it was classed as "interesting"
             # If event is None then we don't care
             self.log.info('Interesting event {} processed'.format(event.name))
-            self._send_slack_report(event)
             self.interesting_events += 1
+            try:
+                self._send_slack_report(event)
+                self.log.info('Slack alert sent')
+            except Exception as err:
+                self.log.error('Slack alert failed')
+                self.log.exception(err)
 
         # Done!
         self.processed_events += 1


### PR DESCRIPTION
What is says on the tin. Since tiles will overlap then simply adding up the contained probability in each will over-count some areas of the sky. Now the total probability *acocunting for overlap* will be reported in the alert, for example:

![slack_tileprob](https://user-images.githubusercontent.com/15014527/56358821-b986e880-61d7-11e9-84a5-79ceb8d6e47a.png)

This uses the new class functions added with GOTO-OBS/goto-tile#60.