### PR TITLE
Changes to database info in image headers

### DIFF
--- a/gtecs/fits.py
+++ b/gtecs/fits.py
@@ -372,7 +372,7 @@ def update_header(header, tel, all_info, log):
         info = all_info['db']['user']
         user_id = info['id']
         user_name = info['name']
-        user_fullname = info['full_name']
+        user_fullname = info['fullname']
     except Exception:
         if from_db:
             # Every Pointing should have a User


### PR DESCRIPTION
As suggested in #413, I've moved fetching the database info from the time the exposures are saved to when they are begun. That should fix the incredibly annoying timing issue.

While I was doing that, I realised I could also add the Event skymap URL to the headers, as just suggested in GOTO-OBS/goto-tile#61. So I've done that too.

Needs testing live, and I'm not going to do that on a Friday evening before a Bank Holiday. Neither should be particularly high-priority fixes anyway.