### PR TITLE
New morning plots in the day marshal

### DIFF
--- a/scripts/daymarshal
+++ b/scripts/daymarshal
@@ -13,8 +13,6 @@ from astroplan import AltitudeConstraint, AtNightConstraint, Observer, is_observ
 import astropy.units as u
 from astropy.time import Time
 
-import gototile
-
 from gtecs import logger
 from gtecs import params
 from gtecs.astronomy import night_startdate, observatory_location, sunalt_time
@@ -57,10 +55,10 @@ def send_coverage_plots():
     """Send Slack messages with nightly coverage and updated survey coverage plots."""
     with db.open_session() as session:
         # Get the base grid
-        db_grid = session.query(db.Grid).all()[-1]
-        grid = gototile.grid.SkyGrid((db_grid.ra_fov, db_grid.dec_fov),
-                                     (db_grid.ra_overlap, db_grid.dec_overlap),
-                                     kind=db_grid.algorithm)
+        db_grid = db.get_current_grid(session)
+
+        # Create a SkyGrid from the database Grid
+        grid = db_grid.get_skygrid()
 
         # Get the dates for the start and end of the night just finished
         midday_today = datetime.datetime.now().replace(hour=12, minute=0, second=0, microsecond=0)
@@ -69,7 +67,7 @@ def send_coverage_plots():
         # Get all pointings observed last night on the grid
         query = session.query(db.Pointing).filter(
             db.Pointing.status == 'completed',
-            db.Pointing.grid_tile_id.in_([i.db_id for i in db_grid.grid_tiles]),
+            db.Pointing.grid == db_grid,
             db.Pointing.stopped_time > midday_yesterday,
             db.Pointing.stopped_time < midday_today,
         )
@@ -136,7 +134,7 @@ def send_coverage_plots():
         # Now get all completed all-sky survey pointings since it started
         query = session.query(db.Pointing).filter(
             db.Pointing.status == 'completed',
-            db.Pointing.survey_tile_id.in_([i.db_id for i in db_survey.survey_tiles]),
+            db.Pointing.survey == db_survey,
         )
         survey_pointings = query.all()
 


### PR DESCRIPTION
Using the new GOTO-tile plotting functions (GOTO-OBS/goto-tile#63 and following, e.g. GOTO-OBS/goto-tile#68 and GOTO-OBS/goto-tile#70) we can make all sorts of pretty plots. And thanks to the new GOTO-alert-inherited Slack code update (see #418) we can attach images to Slack alerts. So why not combine the two?

This PR adds in code to create plots when the day marshal runs (in the morning, after the system is shut down). After doing all the actual important bits, like making sure the dome is closed, it will now produce two new plots and send them to Slack:
* The first is the tile coverage plot for the last night. The tiles that were visible will be highlighted, and the ones that were observed will be outlined in a colour relating to the survey they were part of. All sky survey tiles will be in blue, with other surveys (e.g. for an event) in different colours. On-grid pointings that have no survey defined, e.g. one-offs added with `add_pointing`, will also be shown.
![2019-06-07_observed](https://user-images.githubusercontent.com/15014527/59191687-1c618400-8b78-11e9-9e6d-15a96488fea7.png)

* The second is the up-to-date all-sky survey coverage plot, showing all the tiles that have been observed since the survey started. The tiles observed over the past night will be highlighted in red.
![2019-06-07_survey](https://user-images.githubusercontent.com/15014527/59191725-326f4480-8b78-11e9-95dc-1a406b46a2a7.png)
