### PR TITLE
Add backup params for IERS servers

### DIFF
--- a/gtecs/data/configspec.ini
+++ b/gtecs/data/configspec.ini
@@ -163,6 +163,9 @@ FOCUSRUN_EXPTIME = float(default=30)
 FOCUSRUN_FILTER = string(default='L')
 FOCUSRUN_DELTAS = int_list(default=list())
 
+IERS_A_URL = string(default='http://maia.usno.navy.mil/ser7/finals2000A.all')
+IERS_A_URL_BACKUP = string(default='ftp://cddis.gsfc.nasa.gov/pub/products/iers/finals2000A.all')
+
 ########################################################################
 # Pilot parameters
 NUM_DARKS = integer(default=9)

--- a/gtecs/observing_scripts/update_IERS.py
+++ b/gtecs/observing_scripts/update_IERS.py
@@ -8,21 +8,20 @@ import traceback
 
 from astropy.utils.data import clear_download_cache, download_file
 
-IERS_A_URL = 'http://maia.usno.navy.mil/ser7/finals2000A.all'
-IERS_A_URL_MIRROR = 'http://toshi.nofs.navy.mil/ser7/finals2000A.all'
+from gtecs import params
 
 try:
     print('Downloading IERS_A table...')
-    clear_download_cache(IERS_A_URL)  # This astropy command makes sure nothing's using them
-    download_file(IERS_A_URL, cache=True, show_progress=False)
+    clear_download_cache(params.IERS_A_URL)  # This astropy command makes sure nothing's using them
+    download_file(params.IERS_A_URL, cache=True, show_progress=False)
     print('IERS A table updated')
 
 except Exception:
     # Server is down, try the backup
     try:
         print('Normal URL failed, attempting to use backup...')
-        clear_download_cache(IERS_A_URL_MIRROR)
-        download_file(IERS_A_URL_MIRROR, cache=True, show_progress=False)
+        clear_download_cache(params.IERS_A_URL_BACKUP)
+        download_file(params.IERS_A_URL_BACKUP, cache=True, show_progress=False)
         print('IERS A table updated')
     except Exception:
         print('Error: could not download IERS A tables')

--- a/gtecs/params.py
+++ b/gtecs/params.py
@@ -284,6 +284,9 @@ FOCUSRUN_EXPTIME = config['FOCUSRUN_EXPTIME']
 FOCUSRUN_FILTER = config['FOCUSRUN_FILTER']
 FOCUSRUN_DELTAS = config['FOCUSRUN_DELTAS']
 
+IERS_A_URL = config['IERS_A_URL']
+IERS_A_URL_BACKUP = config['IERS_A_URL_BACKUP']
+
 ############################################################
 # Pilot parameters
 NUM_DARKS = config['NUM_DARKS']


### PR DESCRIPTION
There have been all sorts of issues with the IERS servers, now the defaults are down for maintenance. This PR adds in `ftp://cddis.gsfc.nasa.gov/pub/products/iers/finals2000A.all` for the default backup, but also makes the URLs config parameters so they're easier to change in the future.

See:
https://github.com/astropy/astropy-iers-data/issues/20
https://github.com/astropy/astroplan/issues/427