### PR TITLE
Fix set error

### DIFF
--- a/gtecs/monitors.py
+++ b/gtecs/monitors.py
@@ -190,10 +190,11 @@ class BaseMonitor(ABC):
             if not delay:
                 # Sometimes we don't want to wait
                 self.log.debug('Adding error "{}"'.format(error))
-                if not critical:
-                    self.errors.add(error)
-                else:
-                    self.errors = set(error)
+                # If critical clear all other errors
+                if critical:
+                    self.errors = set()
+                # Add the error to the set
+                self.errors.add(error)
                 return
 
             if error not in self.pending_errors:
@@ -205,11 +206,13 @@ class BaseMonitor(ABC):
                 self.log.debug('"{}" timer: {:.0f}/{:.0f}s'.format(error, error_time, delay))
                 if error_time > delay:
                     self.log.debug('Adding error "{}" after {:.0f}s'.format(error, delay))
+                    # Remove the error from the pending list
                     del self.pending_errors[error]
-                    if not critical:
-                        self.errors.add(error)
-                    else:
-                        self.errors = set(error)
+                    # If critical clear all other errors
+                    if critical:
+                        self.errors = set()
+                    # Add the error to the set
+                    self.errors.add(error)
                     return
 
     def clear_error(self, error):


### PR DESCRIPTION
Fixing a bug added in #463.

This is a silly Python thing.

Flake8 (https://github.com/adamchainz/flake8-comprehensions) complained about
```python
s = set(['string'])
```
so I replaced it with 
```python
s = set('string')
```
but that's wrong, because that brakes the string into its component letters. You could do
```python
s = {'string'}
```
but in the end I went with
```python
s = set()
s.add('string')
```
to be totally explicit.