### PR TITLE
Allow non-symetric UT hardware

### DIFF
--- a/.gtecs.conf
+++ b/.gtecs.conf
@@ -42,15 +42,25 @@ FAKE_DOME = 0
 SITECH_HOST = 127.0.0.1
 SITECH_PORT = 8079
 
-# UT interface dictionary
-[INTERFACES]
-    [[intf1]]
-        UTS = 1, 2
-        CAMERAS = FAKE_CAM1, FAKE_CAM2
-        FOCUSERS = FAKE_FOC1, FAKE_FOC2
-        FILTERWHEELS = FAKE_FW1, FAKE_FW2
-    [[intf2]]
-        UTS = 3, 4
-        CAMERAS = FAKE_CAM3, FAKE_CAM4
-        FOCUSERS = FAKE_FOC3, FAKE_FOC4
-        FILTERWHEELS = FAKE_FW3, FAKE_FW4
+# UT dictionary
+[UTS]
+    [[1]]
+        INTERFACE = intf1
+        CAMERA = CAM_SERIAL_1
+        FOCUSER = FOC_SERIAL_1
+        FILTERWHEEL = FW1_SERIAL_1
+    [[2]]
+        INTERFACE = intf1
+        CAMERA = CAM_SERIAL_2
+        FOCUSER = FOC_SERIAL_2
+        FILTERWHEEL = FW1_SERIAL_2
+    [[3]]
+        INTERFACE = intf2
+        CAMERA = CAM_SERIAL_3
+        FOCUSER = FOC_SERIAL_3
+        FILTERWHEEL = FW1_SERIAL_3
+    [[4]]
+        INTERFACE = intf2
+        CAMERA = CAM_SERIAL_4
+        FOCUSER = FOC_SERIAL_4
+        FILTERWHEEL = FW1_SERIAL_4

--- a/gtecs/daemons/exq_daemon.py
+++ b/gtecs/daemons/exq_daemon.py
@@ -20,8 +20,8 @@ class ExqDaemon(BaseDaemon):
         super().__init__('exq')
 
         # exq is dependent on all the interfaces, cam and filt
-        for daemon_id in params.INTERFACES:
-            self.dependencies.add(daemon_id)
+        for interface_id in params.INTERFACES:
+            self.dependencies.add(interface_id)
         self.dependencies.add('cam')
         self.dependencies.add('filt')
 
@@ -284,7 +284,7 @@ class ExqDaemon(BaseDaemon):
         if int(binning) < 1 or (int(binning) - binning) != 0:
             raise ValueError('Binning factor must be a positive integer')
         if frametype not in params.FRAMETYPE_LIST:
-            raise ValueError("Frame type must be in {}".format(params.FRAMETYPE_LIST))
+            raise ValueError('Frame type must be in {}'.format(params.FRAMETYPE_LIST))
 
         # Call the command
         exposure = Exposure(ut_list, exptime,
@@ -331,7 +331,7 @@ class ExqDaemon(BaseDaemon):
         if int(binning) < 1 or (int(binning) - binning) != 0:
             raise ValueError('Binning factor must be a positive integer')
         if frametype not in params.FRAMETYPE_LIST:
-            raise ValueError("Frame type must be in {}".format(params.FRAMETYPE_LIST))
+            raise ValueError('Frame type must be in {}'.format(params.FRAMETYPE_LIST))
 
         # Call the command
         for i in range(nexp):

--- a/gtecs/daemons/filt_daemon.py
+++ b/gtecs/daemons/filt_daemon.py
@@ -19,8 +19,8 @@ class FiltDaemon(BaseDaemon):
         super().__init__('filt')
 
         # filt is dependent on all the interfaces
-        for daemon_id in params.INTERFACES:
-            self.dependencies.add(daemon_id)
+        for interface_id in params.INTERFACES:
+            self.dependencies.add(interface_id)
 
         # command flags
         self.set_filter_flag = 0
@@ -65,7 +65,7 @@ class FiltDaemon(BaseDaemon):
             if self.set_filter_flag:
                 try:
                     for ut in self.active_uts:
-                        interface_id = params.UT_INTERFACES[ut]
+                        interface_id = params.UT_DICT[ut]['INTERFACE']
                         new_filter_num = params.FILTER_LIST.index(self.new_filter)
 
                         self.log.info('Moving filter wheel {} ({}) to {} ({})'.format(
@@ -90,7 +90,7 @@ class FiltDaemon(BaseDaemon):
             if self.home_filter_flag:
                 try:
                     for ut in self.active_uts:
-                        interface_id = params.UT_INTERFACES[ut]
+                        interface_id = params.UT_DICT[ut]['INTERFACE']
 
                         self.log.info('Homing filter wheel {} ({})'.format(
                                       ut, interface_id))
@@ -129,7 +129,7 @@ class FiltDaemon(BaseDaemon):
         for ut in self.uts:
             # Get info from each interface
             try:
-                interface_id = params.UT_INTERFACES[ut]
+                interface_id = params.UT_DICT[ut]['INTERFACE']
                 interface_info = {}
                 interface_info['interface_id'] = interface_id
 

--- a/gtecs/daemons/foc_daemon.py
+++ b/gtecs/daemons/foc_daemon.py
@@ -19,8 +19,8 @@ class FocDaemon(BaseDaemon):
         super().__init__('foc')
 
         # foc is dependent on all the interfaces
-        for daemon_id in params.INTERFACES:
-            self.dependencies.add(daemon_id)
+        for interface_id in params.INTERFACES:
+            self.dependencies.add(interface_id)
 
         # command flags
         self.move_focuser_flag = 0
@@ -65,7 +65,7 @@ class FocDaemon(BaseDaemon):
             if self.move_focuser_flag:
                 try:
                     for ut in self.active_uts:
-                        interface_id = params.UT_INTERFACES[ut]
+                        interface_id = params.UT_DICT[ut]['INTERFACE']
                         move_steps = self.move_steps[ut]
                         new_pos = self.info[ut]['current_pos'] + move_steps
 
@@ -91,7 +91,7 @@ class FocDaemon(BaseDaemon):
             if self.home_focuser_flag:
                 try:
                     for ut in self.active_uts:
-                        interface_id = params.UT_INTERFACES[ut]
+                        interface_id = params.UT_DICT[ut]['INTERFACE']
 
                         self.log.info('Homing focuser {} ({})'.format(
                                       ut, interface_id))
@@ -132,7 +132,7 @@ class FocDaemon(BaseDaemon):
         for ut in self.uts:
             # Get info from each interface
             try:
-                interface_id = params.UT_INTERFACES[ut]
+                interface_id = params.UT_DICT[ut]['INTERFACE']
                 interface_info = {}
                 interface_info['interface_id'] = interface_id
 

--- a/gtecs/daemons/ut_interface.py
+++ b/gtecs/daemons/ut_interface.py
@@ -383,23 +383,37 @@ def parse_args():
     parser.add_argument('interface_id')
     parser.add_argument('--uts', nargs='+', action='append')
     args = parser.parse_args()
-    interface_id = args.interface_id
-    ut_dicts = args.uts
-    serial_dict = {}
-    for ut_dict in ut_dicts:
-        if len(ut_dict) == 4:
-            # Should be four strings: UT number, cam serial, foc serial, filt serial
-            ut, cam, foc, filt = ut_dict
-            serial_dict[int(ut)] = {'cam': cam, 'foc': foc, 'filt': filt}
-        elif len(ut_dict) == 3:
-            # This UT has no filter wheel
-            ut, cam, foc = ut_dict
-            serial_dict[int(ut)] = {'cam': cam, 'foc': foc, 'filt': None}
-        else:
-            # This UT has no filter wheel or focuser
-            ut, cam = ut_dict
-            serial_dict[int(ut)] = {'cam': cam, 'foc': None, 'filt': None}
 
+    # Interface ID should be first argument
+    interface_id = args.interface_id
+
+    # Each UT should have an ID and list of serials
+    ut_lists = args.uts
+    serial_dict = {}
+    for ut_list in ut_lists:
+        # ID number should be first
+        ut = int(ut_list[0])
+        ut_dict = {}
+
+        # Extract the HW serials
+        for arg in ut_list[1:]:
+            if arg.startswith('cam='):
+                ut_dict['cam'] = arg.strip('cam=')
+            if arg.startswith('foc='):
+                ut_dict['foc'] = arg.strip('foc=')
+            if arg.startswith('filt='):
+                ut_dict['filt'] = arg.strip('filt=')
+
+        # Add `None`s for missing HW
+        if 'cam' not in ut_dict:
+            ut_dict['cam'] = None
+        if 'foc' not in ut_dict:
+            ut_dict['foc'] = None
+        if 'filt' not in ut_dict:
+            ut_dict['filt'] = None
+
+        # Add to main dict
+        serial_dict[ut] = ut_dict
     return interface_id, serial_dict
 
 

--- a/gtecs/data/configspec.ini
+++ b/gtecs/data/configspec.ini
@@ -252,11 +252,7 @@ SLACK_BOT_CHANNEL = string(default=slack_channel)
         PROCESS = string(default=sentinel_daemon.py)
         PINGLIFE = float(default=60.0)
 
-[INTERFACES]
-    [[intf1]]
-        UTS = int_list(default=list(1, 2))
-    [[intf2]]
-        UTS = int_list(default=list(3, 4))
+[UTS]
 
 [POWER_UNITS]
     [[PDU1]]

--- a/gtecs/fits.py
+++ b/gtecs/fits.py
@@ -255,7 +255,7 @@ def update_header(header, ut, all_info, log):
     header["ORIGIN  "] = (params.ORG_NAME, "Origin organisation")
     header["TELESCOP"] = (params.TELESCOPE_NAME, "Origin telescope")
 
-    interface_id = params.UT_INTERFACES[ut]
+    interface_id = params.UT_DICT[ut]['INTERFACE']
     current_exposure = cam_info['current_exposure']
     ut_mask = misc.ut_list_to_mask(current_exposure['ut_list'])
     ut_string = misc.ut_mask_to_string(ut_mask)

--- a/gtecs/misc.py
+++ b/gtecs/misc.py
@@ -282,16 +282,15 @@ def send_email(recipients=params.EMAIL_LIST, subject='GOTO', message='Test'):
 def ut_list_to_mask(ut_list):
     """Convert a UT list to a mask integer."""
     ut_mask = 0
-    all_uts = params.ALL_UTS
-    for i in all_uts:
-        if i in ut_list:
-            ut_mask += 2**(i - 1)
+    for ut in params.UTS:
+        if ut in ut_list:
+            ut_mask += 2**(ut - 1)
     return ut_mask
 
 
 def ut_mask_to_string(ut_mask):
     """Convert a UT mask integer to a string of 0s and 1s."""
-    total_uts = max(params.ALL_UTS)
+    total_uts = max(params.UTS)
     bin_str = format(ut_mask, '0{}b'.format(total_uts))
     ut_str = bin_str[-1 * total_uts:]
     return ut_str
@@ -300,9 +299,8 @@ def ut_mask_to_string(ut_mask):
 def ut_string_to_list(ut_string):
     """Convert a UT string of 0s and 1s to a list."""
     ut_list = []
-    all_uts = params.ALL_UTS
-    for i in all_uts:
-        if ut_string[-1 * i] == '1':
-            ut_list.append(i)
+    for ut in params.UTS:
+        if ut_string[-1 * ut] == '1':
+            ut_list.append(ut)
     ut_list.sort()
     return ut_list

--- a/gtecs/monitors.py
+++ b/gtecs/monitors.py
@@ -984,8 +984,8 @@ class CamMonitor(BaseMonitor):
 
         elif ERROR_DEPENDENCY in self.errors:
             # The cam daemon depends on the interfaces.
-            for daemon_id in params.INTERFACES:
-                if daemon_id in self.bad_dependencies:
+            for interface_id in params.INTERFACES:
+                if interface_id in self.bad_dependencies:
                     # PROBLEM: The interfaces aren't responding.
                     recovery_procedure = {}
                     # SOLUTION 1: Make sure the interfaces are started.
@@ -1088,8 +1088,8 @@ class FiltMonitor(BaseMonitor):
 
         elif ERROR_DEPENDENCY in self.errors:
             # The filt daemon depends on the interfaces.
-            for daemon_id in params.INTERFACES:
-                if daemon_id in self.bad_dependencies:
+            for interface_id in params.INTERFACES:
+                if interface_id in self.bad_dependencies:
                     # PROBLEM: The interfaces aren't responding.
                     recovery_procedure = {}
                     # SOLUTION 1: Make sure the interfaces are started.
@@ -1184,8 +1184,8 @@ class FocMonitor(BaseMonitor):
 
         elif ERROR_DEPENDENCY in self.errors:
             # The foc daemon depends on the interfaces.
-            for daemon_id in params.INTERFACES:
-                if daemon_id in self.bad_dependencies:
+            for interface_id in params.INTERFACES:
+                if interface_id in self.bad_dependencies:
                     # PROBLEM: The interfaces aren't responding.
                     recovery_procedure = {}
                     # SOLUTION 1: Make sure the interfaces are started.
@@ -1273,8 +1273,8 @@ class ExqMonitor(BaseMonitor):
             # Note that all being well the CamMonitor and FiltMonitor will be trying to fix
             # themselves too, but ideally the ExqMonitor should be standalone in case one of them
             # fails.
-            for daemon_id in params.INTERFACES:
-                if daemon_id in self.bad_dependencies:
+            for interface_id in params.INTERFACES:
+                if interface_id in self.bad_dependencies:
                     # PROBLEM: The interfaces aren't responding.
                     recovery_procedure = {}
                     # SOLUTION 1: Make sure the interfaces are started.

--- a/gtecs/observing_scripts/startup.py
+++ b/gtecs/observing_scripts/startup.py
@@ -35,9 +35,9 @@ def run():
 
     # Make all the other daemons and interfaces are running
     execute_command('intf start')
-    for daemon in list(params.DAEMONS):
-        if daemon not in params.INTERFACES:
-            execute_command('{} start'.format(daemon))
+    for daemon_id in list(params.DAEMONS):
+        if daemon_id not in params.INTERFACES:
+            execute_command('{} start'.format(daemon_id))
 
     time.sleep(4)
 

--- a/scripts/cam
+++ b/scripts/cam
@@ -197,7 +197,7 @@ def print_info(info):
     """Print the full info dict."""
     print('####### CAMERA INFO #######')
     for ut in params.UTS_WITH_CAMERAS:
-        print('CAMERA {} ({})'.format(ut, params.UT_INTERFACES[ut]))
+        print('CAMERA {} ({})'.format(ut, params.UT_DICT[ut]['INTERFACE']))
         if info[ut]['status'] != 'Exposing':
             print('Status: {}'.format(info[ut]['status']))
         else:
@@ -226,7 +226,7 @@ def print_info(info):
 def print_info_s(info):
     """Print the info dict in a compact way."""
     for ut in params.UTS_WITH_CAMERAS:
-        print('CAMERA {} ({})'.format(ut, params.UT_INTERFACES[ut]), end=' ')
+        print('CAMERA {} ({})'.format(ut, params.UT_DICT[ut]['INTERFACE']), end=' ')
         if info[ut]['status'] != 'Exposing':
             print('  Temp: {:6.2f}C'.format(info[ut]['ccd_temp']), end=' ')
             print('  [{}]'.format(info[ut]['status']))

--- a/scripts/filt
+++ b/scripts/filt
@@ -125,7 +125,7 @@ def print_info(info):
     """Print the full info dict."""
     print('#### FILTER WHEEL INFO ####')
     for ut in params.UTS_WITH_FILTERWHEELS:
-        print('FILTER WHEEL {} ({})'.format(ut, params.UT_INTERFACES[ut]))
+        print('FILTER WHEEL {} ({})'.format(ut, params.UT_DICT[ut]['INTERFACE']))
         if info[ut]['status'] != 'Moving':
             print('Status: {}'.format(info[ut]['status']))
             if not info[ut]['homed']:
@@ -149,7 +149,7 @@ def print_info(info):
 def print_info_s(info):
     """Print the info dict in a compact way."""
     for ut in params.UTS_WITH_FILTERWHEELS:
-        print('FILTER WHEEL {} ({})'.format(ut, params.UT_INTERFACES[ut]), end=' ')
+        print('FILTER WHEEL {} ({})'.format(ut, params.UT_DICT[ut]['INTERFACE']), end=' ')
         if info[ut]['status'] != 'Moving':
             if not info[ut]['homed']:
                 print('Current filter: UNHOMED', end=' ')

--- a/scripts/foc
+++ b/scripts/foc
@@ -135,7 +135,7 @@ def print_info(info):
     """Print the full info dict."""
     print('###### FOCUSER INFO #######')
     for ut in params.UTS_WITH_FOCUSERS:
-        print('FOCUSER {} ({})'.format(ut, params.UT_INTERFACES[ut]))
+        print('FOCUSER {} ({})'.format(ut, params.UT_DICT[ut]['INTERFACE']))
         if info[ut]['status'] != 'Moving':
             print('Status: {}'.format(info[ut]['status']))
         else:
@@ -154,7 +154,7 @@ def print_info(info):
 def print_info_s(info):
     """Print the info dict in a compact way."""
     for ut in params.UTS_WITH_FOCUSERS:
-        print('FOCUSER {} ({})'.format(ut, params.UT_INTERFACES[ut]), end=' ')
+        print('FOCUSER {} ({})'.format(ut, params.UT_DICT[ut]['INTERFACE']), end=' ')
         if info[ut]['status'] != 'Moving':
             print('  Current position: {}/{}'.format(info[ut]['current_pos'],
                                                      info[ut]['limit']), end=' ')

--- a/scripts/intf
+++ b/scripts/intf
@@ -22,14 +22,15 @@ DAEMON_IDS.sort()
 def get_args(interface_id):
     """Format the arguments to send to the interface script."""
     args = [interface_id]
-    for hw in range(len(params.INTERFACES[interface_id]['UTS'])):
+    for ut in params.INTERFACES[interface_id]:
         args.append('--ut')
-        args.append(params.INTERFACES[interface_id]['UTS'][hw])
-        args.append(params.INTERFACES[interface_id]['CAMERAS'][hw])
-        if params.INTERFACES[interface_id]['FOCUSERS'][hw] is not None:
-            args.append(params.INTERFACES[interface_id]['FOCUSERS'][hw])
-        if params.INTERFACES[interface_id]['FILTERWHEELS'][hw] is not None:
-            args.append(params.INTERFACES[interface_id]['FILTERWHEELS'][hw])
+        args.append(ut)
+        if params.UT_DICT[ut]['CAMERA'] is not None:
+            args.append('cam={}'.format(params.UT_DICT[ut]['CAMERA']))
+        if params.UT_DICT[ut]['FOCUSER'] is not None:
+            args.append('foc={}'.format(params.UT_DICT[ut]['FOCUSER']))
+        if params.UT_DICT[ut]['FILTERWHEEL'] is not None:
+            args.append('filt={}'.format(params.UT_DICT[ut]['FILTERWHEEL']))
     return args
 
 
@@ -123,7 +124,7 @@ def print_info(info):
             if ut in info['cam_serials']:
                 print('{}: {: <14}'.format(ut, info['cam_serials'][ut]), end='  ')
             else:
-                print('                 ', end='  ')
+                print('{}: {: <14}'.format(ut, '----'), end='  ')
         print('')
     if len(info['foc_serials']) > 0:
         print('   Focusers:      ', end='\t')
@@ -131,7 +132,7 @@ def print_info(info):
             if ut in info['foc_serials']:
                 print('{}: {: <14}'.format(ut, info['foc_serials'][ut]), end='  ')
             else:
-                print('                 ', end='  ')
+                print('{}: {: <14}'.format(ut, '----'), end='  ')
         print('')
     if len(info['filt_serials']) > 0:
         print('   Filter Wheels: ', end='\t')
@@ -139,7 +140,7 @@ def print_info(info):
             if ut in info['filt_serials']:
                 print('{}: {: <14}'.format(ut, info['filt_serials'][ut]), end='  ')
             else:
-                print('                 ', end='  ')
+                print('{}: {: <14}'.format(ut, '----'), end='  ')
         print('')
 
 

--- a/scripts/lilith
+++ b/scripts/lilith
@@ -16,7 +16,7 @@ if __name__ == '__main__':
             daemons = list(params.DAEMONS)
 
         # remove individual UT interfaces and replace with one command
-        if any([interface_id in daemons for interface_id in params.INTERFACES]):
+        if any(interface_id in daemons for interface_id in params.INTERFACES):
             for interface_id in params.INTERFACES:
                 if interface_id in daemons:
                     daemons.remove(interface_id)


### PR DESCRIPTION
So when I initially rewrote the UT hardware logic in #446 I expected the hardware in each interface to be symmetric, i.e. we might have some UTs with filter wheels and some without, but each pair would be identical.

It turns out that assumption is not always true. Actually this came up when having issues with the focuser on one UT, and we wanted to disable it moving. The nicest way would be to remove that focuser's serial number from the config file, which would mean the system doesn't know it exists. But because of the above assumption that didn't work: either all the UTs on a given interface had to have focusers, or none of them.

Hence this PR, which should allow this from now on. It does require a placeholder value in the config, but `None` works fine.

For example, if the config file looks like:
```
[INTERFACES]
    [[intf1]]
        UTS = 5, 6
        CAMERAS = fake, fake
        FOCUSERS = fake, None
        FILTERWHEELS = None, None
    [[intf2]]
        UTS = 7, 8
        CAMERAS = fake, fake
        FOCUSERS = fake, fake
        FILTERWHEELS = None, fake
```

then the interfaces should recognise everything that didn't have a `None`:
```
~$ intf info
INTERFACE intf1:
   Cameras:             5: Fake-Cam-01     6: Fake-Cam-01     
   Focusers:            5: Fake-Foc-01                        
INTERFACE intf2:
   Cameras:             7: Fake-Cam-01     8: Fake-Cam-01     
   Focusers:            7: Fake-Foc-01     8: Fake-Foc-01     
   Filter Wheels:                          8: Fake-FW-01 
```