### PR TITLE
Add extra checks and warnings when the pilot starts in manual mode

### DIFF
--- a/gtecs/pilot.py
+++ b/gtecs/pilot.py
@@ -446,7 +446,7 @@ class Pilot(object):
                                     stdin=None)
 
         # start the process and get transport and protocol for control of it
-        self.log.info("starting {}".format(name))
+        self.log.info('starting {}'.format(name))
         self.running_script = name
         self.running_script_transport, self.running_script_protocol = await proc
 
@@ -464,12 +464,12 @@ class Pilot(object):
             if name == 'OBS' and self.current_id is not None:
                 mark_aborted(self.current_id)
 
-        self.log.info("finished {}".format(name))
+        self.log.info('finished {}'.format(name))
         self.running_script = None
 
         # if it was an observation that just finished (aborted or not) force a scheduler check
         if name == 'OBS':
-            self.log.debug("forcing scheduler check".format(name))
+            self.log.debug('forcing scheduler check'.format(name))
             self.force_scheduler_check = True
 
         return retcode, result
@@ -554,9 +554,9 @@ class Pilot(object):
             self.log.info('next task: {}'.format(name))
 
             # wait for the right sun altitude
-            OK = await self.wait_for_sunalt(sunalt, name, rising, ignore_late)
+            can_start = await self.wait_for_sunalt(sunalt, name, rising, ignore_late)
 
-            if not OK:
+            if not can_start:
                 # too late
                 self.log.info('too late to start {}'.format(name))
                 continue
@@ -870,7 +870,7 @@ class Pilot(object):
                 self.log.info('current task will continue')
 
         # does this change suggest a global unpause?
-        unpause = (not any([self.whypause[key] for key in self.whypause if key != reason]) and
+        unpause = (not any(self.whypause[key] for key in self.whypause if key != reason) and
                    not pause)
         if unpause and self.paused:
             # OK, we can resume
@@ -1051,7 +1051,7 @@ class Pilot(object):
             # panic time
             elapsed_time = time.time() - start_time
             if elapsed_time / 60. > mins_until_panic:
-                msg = "IMPORTANT: Pilot cannot close dome!"
+                msg = 'IMPORTANT: Pilot cannot close dome!'
                 send_slack_msg(msg)
                 try:
                     send_email(message=msg)


### PR DESCRIPTION
A few simple changes, making sure that the night marshal routine checks after the flags have been set and then sends an extra warning if the pilot starts in manual mode. 