### PR TITLE
Fix checking of target info for where value is zero

### DIFF
--- a/gtecs/fits.py
+++ b/gtecs/fits.py
@@ -639,19 +639,19 @@ def update_header(header, ut, all_info, log):
         mount_tracking = info['status'] == 'Tracking'
 
         targ_ra = info['target_ra']
-        if targ_ra:
+        if targ_ra is not None:
             targ_ra_str = Angle(targ_ra * u.hour).to_string(sep=':', precision=1, alwayssign=True)
         else:
             targ_ra_str = 'NA'
 
         targ_dec = info['target_dec']
-        if targ_dec:
+        if targ_dec is not None:
             targ_dec_str = Angle(targ_dec * u.deg).to_string(sep=':', precision=1, alwayssign=True)
         else:
             targ_dec_str = 'NA'
 
         targ_dist_a = info['target_dist']
-        if targ_dist_a:
+        if targ_dist_a is not None:
             targ_dist = numpy.around(targ_dist_a, decimals=1)
         else:
             targ_dist = 'NA'


### PR DESCRIPTION
When coordinates `=0`, the headers are populated incorrectly as:
```
RA-TARG = +18:03:18.2 / Requested pointing RA
DEC-TARG = NA / Requested pointing Dec
RA-TEL = +18:03:18.3 / Reported mount pointing RA
DEC-TEL = -0:00:00.1 / Reported mount pointing Dec
```
since `bool(0)` evaluates `False`, this should fix it. I think I have read correctly that they have `None` values if not populated?