### PR TITLE
Add a second step when making initial autofocus move

### DIFF
--- a/gtecs/observing_scripts/autoFocus.py
+++ b/gtecs/observing_scripts/autoFocus.py
@@ -284,7 +284,7 @@ def run(big_step, small_step, nfv, m_l, m_r, delta_x, num_exp=3, exptime=30, fil
         print('Initial HFDs:', initial_hfds.round(1).to_dict())
         print('Current HFDs:', out_hfds.round(1).to_dict())
         print('Trying to move out again...')
-        mask = out_hfds < initial_hfds + 1
+        mask = out_hfds < initial_hfds + 2  # stricter mask
         moving_uts = initial_hfds.index[mask]
         print('UTs to move: {}'.format(','.join([str(ut) for ut in moving_uts])))
         new_positions = {ut: initial_positions[ut] + big_step[ut] / 2 for ut in moving_uts}


### PR DESCRIPTION
A semi-common cause of the autofocus script failing is when the initial "big step" out doesn't seem to be enough to change the HFD values in the focus images. The idea is to assume we start relatively close to the best focus position (i.e. the minimum of the V-curve), and then a big step to the right should put us way up on the right-hand slope. Then the rest of the routine is gradually stepping back down. However if the focus starts over towards the left-hand side of the slope then it's possible that the big step just moves us to a symmetric position on the right-hand side, meaning the HFD value doesn't really change at all. Alternatively we might just get unlucky, there's plenty of random error in the HFD measurements.

This is quite annoying, and only ever really happens to a single UT. See the log below from a few days ago:
```
2020/06/21 21:11:20:INFO - FOC: Initial HFDs: {1: 2.6, 2: 2.2, 3: 3.1, 4: 2.2, 5: 6.1, 6: 5.8, 7: 3.7, 8: 4.7}
2020/06/21 21:11:20:INFO - FOC: Current HFDs: {1: 9.7, 2: 10.3, 3: 10.1, 4: 11.1, 5: 6.5, 6: 6.9, 7: 8.3, 8: 8.5}
2020/06/21 21:11:20:INFO - FOC: Error caught: Restoring original focus positions...
...
2020/06/21 21:11:24:ERROR - FOC: Exception: HFD not changing with focuser position
```

In this case UT5 started with a HFD of 6.1, and after the big step it only went up to 6.5, less than the change of 1 required. Clearly UT5 and UT6 started quite far from the best focus position.

One possibility is to increase the big step distance, however that has knock-on problems with taking more time to step back in and, for the RASAs, getting close to the shaft limit. So instead I've added a small extra bit of code to make a second step of half the distance again, but only for the UTs that weren't already far enough out. In the case above UTs 5&6 would have been told to step out again, and as long as the resulting HFDs are far enough from the initial values then the routine could continue.

It's a fairly minor addition for a relatively rare occurrence, but it should hopefully make these errors that much rarer.