### PR TITLE
Get header daemon info in parallel

### DIFF
--- a/gtecs/daemons/cam_daemon.py
+++ b/gtecs/daemons/cam_daemon.py
@@ -45,8 +45,6 @@ class CamDaemon(BaseDaemon):
             self.latest_run_number = 0
         self.num_taken = 0
 
-        self.pool = ThreadPoolExecutor(max_workers=len(self.uts))
-
         self.current_exposure = None
         self.exposing = False
         self.exposure_start_time = 0


### PR DESCRIPTION
A simple speedup for camera exposures, fetching the info dicts from the other daemons in parallel. This was already being done in parallel to the exposures themselves, but could still take a non-insignificant amount of time if one of the daemons was slow (usually the conditions daemon from what I could see). So short (~<10s) exposures should be somewhat quicker, which will be useful to fit in more calibration frames.