### PR TITLE
Allow camera-specific temperatures

### DIFF
--- a/gtecs/control/params.py
+++ b/gtecs/control/params.py
@@ -103,10 +103,20 @@ for ut in UT_DICT:
             if 'CLASS' not in UT_DICT[ut][hw_class]:
                 raise ValueError('{} for UT {} does not have a valid class'.format(hw_class, ut))
 
+    # Get specific camera operating temperatures
+    if UT_DICT[ut]['CAMERA'] is not None:
+        if 'IMAGING_TEMPERATURE' not in UT_DICT[ut]['CAMERA']:
+            UT_DICT[ut]['CAMERA']['IMAGING_TEMPERATURE'] = config['CAM_IMAGING_TEMPERATURE']
+        if 'STANDBY_TEMPERATURE' not in UT_DICT[ut]['CAMERA']:
+            UT_DICT[ut]['CAMERA']['STANDBY_TEMPERATURE'] = config['CAM_STANDBY_TEMPERATURE']
+
     # Define available filters
+    # NB We add 'FILTERS' to each UT's dict directly, not under 'FILTERWHEEL',
+    # because in cases without a filter wheel (i.e. when UT_DICT[ut]['FILTERWHEEL'] = None)
+    # we still need to define a filter for the UT.
     if UT_DICT[ut]['FILTERWHEEL'] is not None:
         if UT_DICT[ut]['FILTERWHEEL']['CLASS'] in ['None', 'Static', 'Fixed']:
-            # This UT has a "static" filter wheel, so a fixed filter which be given
+            # This UT has a single fixed filter, for us we ignore the filter wheel
             UT_DICT[ut]['FILTERS'] = [UT_DICT[ut]['FILTERWHEEL']['FILTER']]
             UT_DICT[ut]['FILTERWHEEL'] = None
         else:

--- a/scripts/cam
+++ b/scripts/cam
@@ -240,7 +240,7 @@ def query(command, args):
         daemons.check_daemon(daemon_id)
         with daemons.daemon_proxy(daemon_id) as daemon:
             daemon.set_temperature(target_temp, uts)
-        print(f'Target temperature set to {target_temp}\n')
+        print(f'Target temperature set to {target_temp}')
 
     # Help
     elif command in ['help', '?']:


### PR DESCRIPTION
A simple addition requested by @krzul. When we see individual cameras with condensation issues we might want to change the setpoint for them individually instead of for all cameras at once.

With this PR there's still the same usual `CAM_IMAGING_TEMPERATURE` and `CAM_STANDBY_TEMPERATURE` params which will set the values for all cameras, but now you can override them for specific UTs by putting `IMAGING_TEMPERATURE` and/or `STANDBY_TEMPERATURE` in their UT config dicts (for example):

```
CAM_IMAGING_TEMPERATURE = -20
CAM_STANDBY_TEMPERATURE = 15
...
[UTS]
    [[1]]
        INTERFACE = intf1
        [[[OTA]]]
            ...
        [[[CAMERA]]]
            CLASS = FLI
            SERIAL = ML5644917
            IMAGING_TEMPERATURE = -15
            STANDBY_TEMPERATURE = 20
       [[[FOCUSER]]]
            ...
        [[[FILTERWHEEL]]]
            ...
    [[2]]
        ...
```

Then when you do `cam temp cool`/`cam temp warm` it will set each camera to their specific setpoints (`IMAGING`/`STANDBY` respectively).