### PR TITLE
Recentre dithering pattern between sets

### DIFF
--- a/gtecs/control/_daemon_scripts/exq_daemon.py
+++ b/gtecs/control/_daemon_scripts/exq_daemon.py
@@ -438,7 +438,7 @@ class ExqDaemon(BaseDaemon):
             self.log.info('Resuming queue')
             self.paused = False
 
-    def dithering(self, command):
+    def switch_dithering(self, command):
         """Enable or disable dithering between images."""
         if command not in ['on', 'off']:
             raise ValueError("Command must be 'on' or 'off'")

--- a/gtecs/control/_daemon_scripts/exq_daemon.py
+++ b/gtecs/control/_daemon_scripts/exq_daemon.py
@@ -37,6 +37,7 @@ class ExqDaemon(BaseDaemon):
                                ]
         self.dithering = False
         self.dither_time = 0
+        self.dither_delay = params.EXQ_DITHER_DELAY
 
         self.set_number_file = os.path.join(params.FILE_PATH, 'set_number')
         if not os.path.exists(self.set_number_file):
@@ -231,11 +232,13 @@ class ExqDaemon(BaseDaemon):
                                 info = daemon.get_info(force_update=True)
 
                             # Continue when the mount is tracking, and the last move was after the
-                            # dithering command (otherwise the status doesn't change fast enough)
+                            # dithering command (otherwise the status doesn't change fast enough).
+                            # We also add a delay since the mount tracking status can be
+                            # set too early before it's properly settled.
                             if (info['status'] == 'Tracking' and
                                     'last_move_time' in info and
                                     info['last_move_time'] > self.dither_time and
-                                    self.loop_time > info['last_move_time'] + 1):
+                                    self.loop_time > self.dither_time + self.dither_delay):
                                 self.log.info('{}: Mount tracking'.format(setstr))
                                 self.dithering = False
                                 self.exposure_state = 'mount_tracking'  # continue to state 7

--- a/gtecs/control/_daemon_scripts/exq_daemon.py
+++ b/gtecs/control/_daemon_scripts/exq_daemon.py
@@ -438,6 +438,20 @@ class ExqDaemon(BaseDaemon):
             self.log.info('Resuming queue')
             self.paused = False
 
+    def dithering(self, command):
+        """Enable or disable dithering between images."""
+        if command not in ['on', 'off']:
+            raise ValueError("Command must be 'on' or 'off'")
+
+        if command == 'on' and self.dithering_enabled is False:
+            self.log.info('Enabling dithering')
+            self.dithering_enabled = True
+            self.dependencies.add('mnt')
+        elif command == 'off' and self.dithering_enabled is True:
+            self.log.info('Disabling dithering')
+            self.dithering_enabled = False
+            self.dependencies.discard('mnt')
+
     # Info function
     def get_info_string(self, verbose=False, force_update=False):
         """Get a string for printing status info."""

--- a/gtecs/control/_daemon_scripts/exq_daemon.py
+++ b/gtecs/control/_daemon_scripts/exq_daemon.py
@@ -116,12 +116,15 @@ class ExqDaemon(BaseDaemon):
                                 # If it's the start of a new set then make sure we're in position
                                 # If we give no coordinates it will slew to the current target,
                                 # which will reset any offsets from previous dithers
-                                msg = f'{setstr}: Centring mount on target position'
-                                self.log.info(msg)
-                                with daemon_proxy('mnt') as daemon:
-                                    daemon.slew(coords=None)
-                                self.dither_time = self.loop_time
-                                self.dithering = True
+                                # However, we only want to do this if we've been dithering
+                                # since the last slew command. So we check the last move type first.
+                                if info['last_move_type'] == 'guide':
+                                    msg = f'{setstr}: Recentring mount on target position'
+                                    self.log.info(msg)
+                                    with daemon_proxy('mnt') as daemon:
+                                        daemon.slew(coords=None)
+                                    self.dither_time = self.loop_time
+                                    self.dithering = True
                             else:
                                 # For subsequent exposures in a set, offset the mount slightly
                                 # using pulse guiding

--- a/gtecs/control/_daemon_scripts/mnt_daemon.py
+++ b/gtecs/control/_daemon_scripts/mnt_daemon.py
@@ -46,6 +46,7 @@ class MntDaemon(BaseDaemon):
         # mount variables
         self.target = None
         self.last_move_time = None
+        self.last_move_type = None
         self.offset_direction = None
         self.offset_distance = None
         self.guide_direction = None
@@ -139,6 +140,7 @@ class MntDaemon(BaseDaemon):
                     if reply:
                         self.log.info(reply)
                     self.last_move_time = self.loop_time
+                    self.last_move_type = 'slew'
                 except Exception:
                     self.log.error('slew command failed')
                     self.log.debug('', exc_info=True)
@@ -154,6 +156,7 @@ class MntDaemon(BaseDaemon):
                     if reply:
                         self.log.info(reply)
                     self.last_move_time = self.loop_time
+                    self.last_move_type = 'track'
                 except Exception:
                     self.log.error('track command failed')
                     self.log.debug('', exc_info=True)
@@ -183,6 +186,7 @@ class MntDaemon(BaseDaemon):
                     if reply:
                         self.log.info(reply)
                     self.last_move_time = self.loop_time
+                    self.last_move_type = 'park'
                 except Exception:
                     self.log.error('park command failed')
                     self.log.debug('', exc_info=True)
@@ -215,6 +219,7 @@ class MntDaemon(BaseDaemon):
                     if reply:
                         self.log.info(reply)
                     self.last_move_time = self.loop_time
+                    self.last_move_type = 'offset'
                 except Exception:
                     self.log.error('offset command failed')
                     self.log.debug('', exc_info=True)
@@ -233,6 +238,7 @@ class MntDaemon(BaseDaemon):
                     if reply:
                         self.log.info(reply)
                     self.last_move_time = self.loop_time
+                    self.last_move_type = 'guide'
                 except Exception:
                     self.log.error('pulse_guide command failed')
                     self.log.debug('', exc_info=True)
@@ -272,7 +278,6 @@ class MntDaemon(BaseDaemon):
                     c = self.mount.set_trackrate(self.trackrate_ra, self.trackrate_dec)
                     if c:
                         self.log.info(c)
-                    self.last_move_time = self.loop_time
                 except Exception:
                     self.log.error('set_trackrate command failed')
                     self.log.debug('', exc_info=True)
@@ -621,6 +626,7 @@ class MntDaemon(BaseDaemon):
             temp_info['target_az'] = None
         temp_info['target_dist'] = self.target_distance
         temp_info['last_move_time'] = self.last_move_time
+        temp_info['last_move_type'] = self.last_move_type
         temp_info['trackrate_ra'] = self.trackrate_ra
         temp_info['trackrate_dec'] = self.trackrate_dec
         temp_info['nonsidereal'] = self.trackrate_ra != 0 or self.trackrate_dec != 0

--- a/gtecs/control/_daemon_scripts/mnt_daemon.py
+++ b/gtecs/control/_daemon_scripts/mnt_daemon.py
@@ -450,6 +450,7 @@ class MntDaemon(BaseDaemon):
             elif isinstance(self.mount, (DDM500, FakeDDM500)):
                 temp_info['class'] = 'ASA'
                 temp_info['tracking_rate'] = self.mount.tracking_rate
+                temp_info['guide_rate'] = self.mount.guide_rate
                 temp_info['motors_on'] = self.mount.motors_on
                 temp_info['pier_side'] = self.mount.pier_side
                 if params.FORCE_MOUNT_PIER_SIDE in [0, 1]:
@@ -554,6 +555,7 @@ class MntDaemon(BaseDaemon):
             elif isinstance(self.mount, (DDM500, FakeDDM500)):
                 temp_info['class'] = 'ASA'
                 temp_info['tracking_rate'] = None
+                temp_info['guide_rate'] = None
                 temp_info['motors_on'] = None
                 temp_info['pier_side'] = None
                 temp_info['target_pier_side'] = None

--- a/gtecs/control/data/configspec.ini
+++ b/gtecs/control/data/configspec.ini
@@ -148,7 +148,7 @@ MIN_HEADER_HIST_TIME = integer(default=30)
 ############################################################
 # Exposure Queue parameters
 EXQ_DITHERING = integer(default=0)
-DITHERING_DURATION = float(default=1000)
+EXQ_DITHER_DELAY = float(default=1)
 
 ########################################################################
 # Power parameters

--- a/gtecs/control/params.py
+++ b/gtecs/control/params.py
@@ -279,7 +279,7 @@ MIN_HEADER_HIST_TIME = config['MIN_HEADER_HIST_TIME']
 ############################################################
 # Exposure Queue parameters
 EXQ_DITHERING = config['EXQ_DITHERING']
-DITHERING_DURATION = config['DITHERING_DURATION']
+EXQ_DITHER_DELAY = config['EXQ_DITHER_DELAY']
 
 ############################################################
 # Power parameters

--- a/scripts/exq
+++ b/scripts/exq
@@ -482,6 +482,20 @@ def query(command, args):
             daemon.resume()
         print('Exposure queue resumed')
 
+    elif command == 'dithering':
+        if len(args) == 1:
+            command = args[0]
+        else:
+            raise ValueError('Invalid arguments')
+        daemons.check_daemon(daemon_id)
+        with daemons.daemon_proxy(daemon_id) as daemon:
+            daemon.switch_dithering(command)
+        if command == 'on':
+            out_str = 'Dithering enabled'
+        elif command == 'off':
+            out_str = 'Dithering disabled'
+        print(out_str)
+
     elif command in ['get', 'list', 'ls']:
         if len(args) == 0:
             list_type = 'simple'
@@ -524,6 +538,7 @@ def query(command, args):
             '  multbias nexp [uts] binning',
             '  pause                          pause taking exposures',
             '  unpause/resume                 resumes taking exposures',
+            '  dithering on|off               enable/disable dithering between exposures',
             '  list [-v]                      lists the current queue',
             '  clear                          empty the queue',
             '  info/status [-r|-v] [-f]       report current status [raw/verbose/force-update]',


### PR DESCRIPTION
See #670, in short when observing multiple sets on the same target we were dithering beyond the mount limit.

Quite simply, this PR adds in a recentring slew every time we start a new set. This will admittedly mean we spend a bit more time per pointing, a second or two, but it will be vital for pointings with multiple sets.

Closes #670.

I also added a command `exq dithering on|off`, based on `cam measure_hfds`. This isn't actually used anywhere, but it goes a bit of a way towards #579 - if we ever added the option to turn off dithering to particular pointings then the observe script could switch the exq daemon here, rather than having to add a new flag into the whole exposure system.